### PR TITLE
Fix for introspection 

### DIFF
--- a/test/service/test_export.py
+++ b/test/service/test_export.py
@@ -94,3 +94,20 @@ async def test_export_alias():
                 member='some_method'))
     assert result.message_type is MessageType.METHOD_RETURN, result.body[0]
     assert interface._method_called
+
+
+@pytest.mark.asyncio
+async def test_export_introspection():
+    interface = ExampleInterface('test.interface')
+    interface2 = ExampleInterface('test.interface2')
+
+    export_path = '/test/path'
+    export_path2 = '/test/path/child'
+
+    bus = await MessageBus().connect()
+    bus.export(export_path, interface)
+    bus.export(export_path2, interface2)
+
+    root = bus._introspect_export_path('/')
+    assert len(root.nodes) == 1
+


### PR DESCRIPTION
This patch fixes the way introspection generates node structure for requested path. 

Lets export more than one interface under similar path, eg.:
`'/test/path'` 
`'/test/path/child'` 

If a client introspects the root path '/' the response will include duplicated child node:
`<node name="/">`
`  <node name="com" />`
`    <node name="com" />`
`</node>"`

Client recursively asking and building interface tree will cause n^2 visible service interfaces where n is a number of actual service interfaces exported.
This patch fixes this behavior (test case included) 
