### PR TITLE
ObjectManager interface added

### DIFF
--- a/dbus_next/aio/message_bus.py
+++ b/dbus_next/aio/message_bus.py
@@ -28,19 +28,14 @@ class MessageBus(BaseMessageBus):
     :type bus_type: :class:`BusType <dbus_next.BusType>`
     :param bus_address: A specific bus address to connect to. Should not be
         used under normal circumstances.
-    :param expanded_intr: An option to select expanded interface tree in introspection or just
-        exported interfaces.
-    :type expanded_intr: bool
 
     :ivar unique_name: The unique name of the message bus connection. It will
         be :class:`None` until the message bus connects.
     :vartype unique_name: str
     """
 
-    def __init__(self, bus_address: str = None,
-                 bus_type: BusType = BusType.SESSION,
-                 expanded_intr: Optional[bool] = False):
-        super().__init__(bus_address, bus_type, ProxyObject, expanded_intr)
+    def __init__(self, bus_address: str = None, bus_type: BusType = BusType.SESSION):
+        super().__init__(bus_address, bus_type, ProxyObject)
         self._loop = asyncio.get_event_loop()
         self._unmarshaller = Unmarshaller(self._stream)
 

--- a/dbus_next/aio/message_bus.py
+++ b/dbus_next/aio/message_bus.py
@@ -33,7 +33,6 @@ class MessageBus(BaseMessageBus):
         be :class:`None` until the message bus connects.
     :vartype unique_name: str
     """
-
     def __init__(self, bus_address: str = None, bus_type: BusType = BusType.SESSION):
         super().__init__(bus_address, bus_type, ProxyObject)
         self._loop = asyncio.get_event_loop()

--- a/dbus_next/aio/message_bus.py
+++ b/dbus_next/aio/message_bus.py
@@ -28,14 +28,19 @@ class MessageBus(BaseMessageBus):
     :type bus_type: :class:`BusType <dbus_next.BusType>`
     :param bus_address: A specific bus address to connect to. Should not be
         used under normal circumstances.
+    :param expanded_intr: An option to select expanded interface tree in introspection or just
+        exported interfaces.
+    :type expanded_intr: bool
 
     :ivar unique_name: The unique name of the message bus connection. It will
         be :class:`None` until the message bus connects.
     :vartype unique_name: str
     """
 
-    def __init__(self, bus_address: str = None, bus_type: BusType = BusType.SESSION):
-        super().__init__(bus_address, bus_type, ProxyObject)
+    def __init__(self, bus_address: str = None,
+                 bus_type: BusType = BusType.SESSION,
+                 expanded_intr: Optional[bool] = False):
+        super().__init__(bus_address, bus_type, ProxyObject, expanded_intr)
         self._loop = asyncio.get_event_loop()
         self._unmarshaller = Unmarshaller(self._stream)
 

--- a/dbus_next/aio/proxy_object.py
+++ b/dbus_next/aio/proxy_object.py
@@ -65,7 +65,6 @@ class ProxyInterface(BaseProxyInterface):
     If the service returns an error for a DBus call, a :class:`DBusError
     <dbus_next.DBusError>` will be raised with information about the error.
     """
-
     def _add_method(self, intr_method):
         async def method_fn(*args):
             msg = await self.bus.call(
@@ -128,7 +127,6 @@ class ProxyObject(BaseProxyObject):
 
     For more information, see the :class:`BaseProxyObject <dbus_next.proxy_object.BaseProxyObject>`.
     """
-
     def __init__(self, bus_name: str, path: str, introspection: Union[intr.Node, str, ET.Element],
                  bus: BaseMessageBus):
         super().__init__(bus_name, path, introspection, bus, ProxyInterface)

--- a/dbus_next/glib/message_bus.py
+++ b/dbus_next/glib/message_bus.py
@@ -135,17 +135,22 @@ class MessageBus(BaseMessageBus):
     :type bus_type: :class:`BusType <dbus_next.BusType>`
     :param bus_address: A specific bus address to connect to. Should not be
         used under normal circumstances.
+    :param expanded_intr: An option to select expanded interface tree in introspection or just
+        exported interfaces.
+    :type expanded_intr: bool
 
     :ivar unique_name: The unique name of the message bus connection. It will
         be :class:`None` until the message bus connects.
     :vartype unique_name: str
     """
 
-    def __init__(self, bus_address: str = None, bus_type: BusType = BusType.SESSION):
+    def __init__(self, bus_address: str = None,
+                 bus_type: BusType = BusType.SESSION,
+                 expanded_intr: Optional[bool] = False):
         if _import_error:
             raise _import_error
 
-        super().__init__(bus_address, bus_type, ProxyObject)
+        super().__init__(bus_address, bus_type, ProxyObject, expanded_intr)
         self._main_context = GLib.main_context_default()
 
     def connect(self, connect_notify: Callable[['MessageBus', Optional[Exception]], None] = None):

--- a/dbus_next/glib/message_bus.py
+++ b/dbus_next/glib/message_bus.py
@@ -135,22 +135,17 @@ class MessageBus(BaseMessageBus):
     :type bus_type: :class:`BusType <dbus_next.BusType>`
     :param bus_address: A specific bus address to connect to. Should not be
         used under normal circumstances.
-    :param expanded_intr: An option to select expanded interface tree in introspection or just
-        exported interfaces.
-    :type expanded_intr: bool
 
     :ivar unique_name: The unique name of the message bus connection. It will
         be :class:`None` until the message bus connects.
     :vartype unique_name: str
     """
 
-    def __init__(self, bus_address: str = None,
-                 bus_type: BusType = BusType.SESSION,
-                 expanded_intr: Optional[bool] = False):
+    def __init__(self, bus_address: str = None, bus_type: BusType = BusType.SESSION):
         if _import_error:
             raise _import_error
 
-        super().__init__(bus_address, bus_type, ProxyObject, expanded_intr)
+        super().__init__(bus_address, bus_type, ProxyObject)
         self._main_context = GLib.main_context_default()
 
     def connect(self, connect_notify: Callable[['MessageBus', Optional[Exception]], None] = None):

--- a/dbus_next/glib/message_bus.py
+++ b/dbus_next/glib/message_bus.py
@@ -140,7 +140,6 @@ class MessageBus(BaseMessageBus):
         be :class:`None` until the message bus connects.
     :vartype unique_name: str
     """
-
     def __init__(self, bus_address: str = None, bus_type: BusType = BusType.SESSION):
         if _import_error:
             raise _import_error

--- a/dbus_next/glib/proxy_object.py
+++ b/dbus_next/glib/proxy_object.py
@@ -102,7 +102,6 @@ class ProxyInterface(BaseProxyInterface):
     :class:`DBusError <dbus_next.DBusError>` will be raised with information
     about the error.
     """
-
     def _add_method(self, intr_method):
         in_len = len(intr_method.in_args)
         out_len = len(intr_method.out_args)
@@ -270,7 +269,6 @@ class ProxyObject(BaseProxyObject):
 
     For more information, see the :class:`BaseProxyObject <dbus_next.proxy_object.BaseProxyObject>`.
     """
-
     def __init__(self, bus_name: str, path: str, introspection: Union[intr.Node, str, ET.Element],
                  bus: BaseMessageBus):
         super().__init__(bus_name, path, introspection, bus, ProxyInterface)

--- a/dbus_next/introspection.py
+++ b/dbus_next/introspection.py
@@ -28,7 +28,6 @@ class Arg:
         - :class:`InvalidSignatureError <dbus_next.InvalidSignatureError>` - If the signature is not valid.
         - :class:`InvalidIntrospectionError <dbus_next.InvalidIntrospectionError>` - If the signature is not a single complete type.
     """
-
     def __init__(self,
                  signature: Union[SignatureType, str],
                  direction: List[ArgDirection] = None,
@@ -101,7 +100,6 @@ class Signal:
     :raises:
         - :class:`InvalidMemberNameError <dbus_next.InvalidMemberNameError>` - If the name of the signal is not a valid member name.
     """
-
     def __init__(self, name: str, args: List[Arg] = None):
         if name is not None:
             assert_member_name_valid(name)
@@ -165,7 +163,6 @@ class Method:
     :raises:
         - :class:`InvalidMemberNameError <dbus_next.InvalidMemberNameError>` - If the name of this method is not valid.
     """
-
     def __init__(self, name: str, in_args: List[Arg] = [], out_args: List[Arg] = []):
         assert_member_name_valid(name)
 
@@ -238,7 +235,6 @@ class Property:
         - :class `InvalidSignatureError <dbus_next.InvalidSignatureError>` - If the given signature is not valid.
         - :class: `InvalidMemberNameError <dbus_next.InvalidMemberNameError>` - If the member name is not valid.
     """
-
     def __init__(self, name: str, signature: str,
                  access: PropertyAccess = PropertyAccess.READWRITE):
         assert_member_name_valid(name)
@@ -303,7 +299,6 @@ class Interface:
     :raises:
         - :class:`InvalidInterfaceNameError <dbus_next.InvalidInterfaceNameError>` - If the name is not a valid interface name.
     """
-
     def __init__(self,
                  name: str,
                  methods: List[Method] = None,
@@ -387,7 +382,6 @@ class Node:
     :raises:
         - :class:`InvalidIntrospectionError <dbus_next.InvalidIntrospectionError>` - If the name is not a valid node name.
     """
-
     def __init__(self, name: str = None, interfaces: List[Interface] = None, is_root: bool = True):
         if not is_root and not name:
             raise InvalidIntrospectionError('child nodes must have a "name" attribute')
@@ -535,14 +529,17 @@ class Node:
                         Interface('org.freedesktop.DBus.ObjectManager',
                                   methods=[
                                       Method('GetManagedObjects',
-                                             out_args=[Arg('a{oa{sa{sv}}}', ArgDirection.OUT,
-                                                           'objpath_interfaces_and_properties')]),
+                                             out_args=[
+                                                 Arg('a{oa{sa{sv}}}', ArgDirection.OUT,
+                                                     'objpath_interfaces_and_properties')
+                                             ]),
                                   ],
                                   signals=[
                                       Signal('InterfacesAdded',
                                              args=[
                                                  Arg('o', ArgDirection.OUT, 'object_path'),
-                                                 Arg('a{sa{sv}}', ArgDirection.OUT, 'interfaces_and_properties'),
+                                                 Arg('a{sa{sv}}', ArgDirection.OUT,
+                                                     'interfaces_and_properties'),
                                              ]),
                                       Signal('InterfacesRemoved',
                                              args=[

--- a/dbus_next/introspection.py
+++ b/dbus_next/introspection.py
@@ -488,6 +488,7 @@ class Node:
         * ``org.freedesktop.DBus.Introspectable``
         * ``org.freedesktop.DBus.Peer``
         * ``org.freedesktop.DBus.Properties``
+        * ``org.freedesktop.DBus.ObjectManager``
         """
         return Node(name,
                     is_root=True,
@@ -530,5 +531,23 @@ class Node:
                                                  Arg('as', ArgDirection.OUT,
                                                      'invalidated_properties')
                                              ])
-                                  ])
+                                  ]),
+                        Interface('org.freedesktop.DBus.ObjectManager',
+                                  methods=[
+                                      Method('GetManagedObjects',
+                                             out_args=[Arg('a{oa{sa{sv}}}', ArgDirection.OUT,
+                                                           'objpath_interfaces_and_properties')]),
+                                  ],
+                                  signals=[
+                                      Signal('InterfacesAdded',
+                                             args=[
+                                                 Arg('o', ArgDirection.OUT, 'object_path'),
+                                                 Arg('a{sa{sv}}', ArgDirection.OUT, 'interfaces_and_properties'),
+                                             ]),
+                                      Signal('InterfacesRemoved',
+                                             args=[
+                                                 Arg('o', ArgDirection.OUT, 'object_path'),
+                                                 Arg('as', ArgDirection.OUT, 'interfaces'),
+                                             ])
+                                  ]),
                     ])

--- a/dbus_next/message.py
+++ b/dbus_next/message.py
@@ -54,7 +54,6 @@ class Message:
         - :class:`InvalidMemberNameError` - If ``member`` is not a valid member name.
         - :class:`InvalidInterfaceNameError` - If ``error_name`` or ``interface`` is not a valid interface name.
     """
-
     def __init__(self,
                  destination: str = None,
                  path: str = None,

--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -38,6 +38,9 @@ class BaseMessageBus:
         Must be passed in by an implementation that supports the high-level client.
     :type ProxyObject: Type[:class:`BaseProxyObject
         <dbus_next.proxy_object.BaseProxyObject>`]
+    :param expanded_intr: An option to select expanded interface tree in introspection or just
+        exported interfaces.
+    :type expanded_intr: bool
 
     :ivar unique_name: The unique name of the message bus connection. It will
         be :class:`None` until the message bus connects.
@@ -47,7 +50,8 @@ class BaseMessageBus:
     def __init__(self,
                  bus_address: Optional[str] = None,
                  bus_type: BusType = BusType.SESSION,
-                 ProxyObject: Optional[Type[BaseProxyObject]] = None):
+                 ProxyObject: Optional[Type[BaseProxyObject]] = None,
+                 expanded_intr: Optional[bool] = False):
         self.unique_name = None
         self._disconnected = False
 
@@ -64,6 +68,7 @@ class BaseMessageBus:
         self._bus_address = parse_address(bus_address) if bus_address else parse_address(
             get_bus_address(bus_type))
         self._ProxyObject = ProxyObject
+        self._expanded = expanded_intr
 
         # machine id is lazy loaded
         self._machine_id = None
@@ -404,7 +409,7 @@ class BaseMessageBus:
             for interface in self._path_exports[path]:
                 node.interfaces.append(interface.introspect())
         else:
-            node = intr.Node(path)
+            node = intr.Node.default(path) if self._expanded else intr.Node(path)
 
         children = set()
 
@@ -586,6 +591,8 @@ class BaseMessageBus:
                 handler = self._default_ping_handler
             elif msg._matches(member='GetMachineId', signature=''):
                 handler = self._default_get_machine_id_handler
+        elif msg._matches(interface='org.freedesktop.DBus.ObjectManager', member='GetManagedObjects'):
+            handler = self._default_object_manager
 
         else:
             for interface in self._path_exports.get(msg.path, []):
@@ -632,6 +639,19 @@ class BaseMessageBus:
                     path='/org/freedesktop/DBus',
                     interface='org.freedesktop.DBus.Peer',
                     member='GetMachineId'), reply_handler)
+
+    def _default_object_manager(self, msg):
+        result = {}
+
+        for node in self._path_exports:
+            if not node.startswith(msg.path):
+                continue
+
+            result[node] = {}
+            for interface in self._path_exports[node]:
+                result[node][interface.name] = self._get_all_properties(interface)
+
+        return Message.new_method_return(msg, 'a{oa{sa{sv}}}', [result])
 
     def _default_properties_handler(self, msg):
         methods = {'Get': 'ss', 'Set': 'ssv', 'GetAll': 's'}
@@ -686,13 +706,18 @@ class BaseMessageBus:
                 return Message.new_method_return(msg)
 
         elif msg.member == 'GetAll':
-            result = {}
-            for prop in ServiceInterface._get_properties(interface):
-                if prop.disabled or not prop.access.readable():
-                    continue
-                result[prop.name] = Variant(prop.signature,
-                                            getattr(interface, prop.prop_getter.__name__))
-
+            result = self._get_all_properties(interface)
             return Message.new_method_return(msg, 'a{sv}', [result])
         else:
             assert False
+
+    def _get_all_properties(self, interface):
+        result = {}
+
+        for prop in ServiceInterface._get_properties(interface):
+            if prop.disabled or not prop.access.readable():
+                continue
+            result[prop.name] = Variant(prop.signature,
+                                        getattr(interface, prop.prop_getter.__name__))
+
+        return result

--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -43,7 +43,6 @@ class BaseMessageBus:
         be :class:`None` until the message bus connects.
     :vartype unique_name: str
     """
-
     def __init__(self,
                  bus_address: Optional[str] = None,
                  bus_type: BusType = BusType.SESSION,
@@ -586,7 +585,8 @@ class BaseMessageBus:
                 handler = self._default_ping_handler
             elif msg._matches(member='GetMachineId', signature=''):
                 handler = self._default_get_machine_id_handler
-        elif msg._matches(interface='org.freedesktop.DBus.ObjectManager', member='GetManagedObjects'):
+        elif msg._matches(interface='org.freedesktop.DBus.ObjectManager',
+                          member='GetManagedObjects'):
             handler = self._default_object_manager
 
         else:
@@ -639,7 +639,7 @@ class BaseMessageBus:
         result = {}
 
         for node in self._path_exports:
-            if not node.startswith(msg.path+'/') and msg.path is not '/':
+            if not node.startswith(msg.path + '/') and msg.path != '/':
                 continue
 
             result[node] = {}
@@ -712,7 +712,7 @@ class BaseMessageBus:
         for prop in ServiceInterface._get_properties(interface):
             if prop.disabled or not prop.access.readable():
                 continue
-            result[prop.name] = Variant(prop.signature,
-                                        getattr(interface, prop.prop_getter.__name__))
+            result[prop.name] = Variant(prop.signature, getattr(interface,
+                                                                prop.prop_getter.__name__))
 
         return result

--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -38,9 +38,6 @@ class BaseMessageBus:
         Must be passed in by an implementation that supports the high-level client.
     :type ProxyObject: Type[:class:`BaseProxyObject
         <dbus_next.proxy_object.BaseProxyObject>`]
-    :param expanded_intr: An option to select expanded interface tree in introspection or just
-        exported interfaces.
-    :type expanded_intr: bool
 
     :ivar unique_name: The unique name of the message bus connection. It will
         be :class:`None` until the message bus connects.
@@ -50,8 +47,7 @@ class BaseMessageBus:
     def __init__(self,
                  bus_address: Optional[str] = None,
                  bus_type: BusType = BusType.SESSION,
-                 ProxyObject: Optional[Type[BaseProxyObject]] = None,
-                 expanded_intr: Optional[bool] = False):
+                 ProxyObject: Optional[Type[BaseProxyObject]] = None):
         self.unique_name = None
         self._disconnected = False
 
@@ -68,7 +64,6 @@ class BaseMessageBus:
         self._bus_address = parse_address(bus_address) if bus_address else parse_address(
             get_bus_address(bus_type))
         self._ProxyObject = ProxyObject
-        self._expanded = expanded_intr
 
         # machine id is lazy loaded
         self._machine_id = None
@@ -409,7 +404,7 @@ class BaseMessageBus:
             for interface in self._path_exports[path]:
                 node.interfaces.append(interface.introspect())
         else:
-            node = intr.Node.default(path) if self._expanded else intr.Node(path)
+            node = intr.Node(path)
 
         children = set()
 

--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -644,7 +644,7 @@ class BaseMessageBus:
         result = {}
 
         for node in self._path_exports:
-            if not node.startswith(msg.path):
+            if not node.startswith(msg.path+'/') and msg.path is not '/':
                 continue
 
             result[node] = {}

--- a/dbus_next/proxy_object.py
+++ b/dbus_next/proxy_object.py
@@ -37,7 +37,6 @@ class BaseProxyInterface:
     :ivar bus: The message bus this proxy interface is connected to.
     :vartype bus: :class:`BaseMessageBus <dbus_next.message_bus.BaseMessageBus>`
     """
-
     def __init__(self, bus_name, path, introspection, bus):
 
         self.bus_name = bus_name
@@ -104,7 +103,6 @@ class BaseProxyObject:
         - :class:`InvalidObjectPathError <dbus_next.InvalidObjectPathError>` - If the given object path is not valid.
         - :class:`InvalidIntrospectionError <dbus_next.InvalidIntrospectionError>` - If the introspection data for the node is not valid.
     """
-
     def __init__(self, bus_name: str, path: str, introspection: Union[intr.Node, str, ET.Element],
                  bus: 'message_bus.BaseMessageBus', ProxyInterface: Type[BaseProxyInterface]):
         assert_object_path_valid(path)

--- a/dbus_next/service.py
+++ b/dbus_next/service.py
@@ -317,7 +317,6 @@ class ServiceInterface:
         valid interface name.
     :vartype name: str
     """
-
     def __init__(self, name: str):
         # TODO cannot be overridden by a dbus member
         self.name = name

--- a/dbus_next/signature.py
+++ b/dbus_next/signature.py
@@ -291,7 +291,6 @@ class SignatureTree:
     :raises:
         :class:`InvalidSignatureError` if the given signature is not valid.
     """
-
     def __init__(self, signature: str = ''):
         self.signature = signature
 
@@ -353,7 +352,6 @@ class Variant:
         :class:`InvalidSignatureError` if the signature is not valid.
         :class:`SignatureBodyMismatchError` if the signature does not match the body.
     """
-
     def __init__(self, signature: Union[str, SignatureTree, SignatureType], value: Any):
         signature_str = ''
         signature_tree = None

--- a/test/service/test_export.py
+++ b/test/service/test_export.py
@@ -110,4 +110,3 @@ async def test_export_introspection():
 
     root = bus._introspect_export_path('/')
     assert len(root.nodes) == 1
-

--- a/test/service/test_standard_interfaces.py
+++ b/test/service/test_standard_interfaces.py
@@ -1,4 +1,5 @@
-from dbus_next.service import ServiceInterface
+from dbus_next.service import ServiceInterface, dbus_property, PropertyAccess
+from dbus_next.signature import Variant
 from dbus_next.aio import MessageBus
 from dbus_next import Message, MessageType, introspection as intr
 
@@ -10,6 +11,21 @@ standard_interfaces_count = len(intr.Node.default().interfaces)
 class ExampleInterface(ServiceInterface):
     def __init__(self, name):
         super().__init__(name)
+
+
+class ExampleComplexInterface(ServiceInterface):
+    def __init__(self, name):
+        self._foo = 42
+        self._bar = 'str'
+        super().__init__(name)
+
+    @dbus_property(access=PropertyAccess.READ)
+    def Foo(self) -> 'y':
+        return self._foo
+
+    @dbus_property(access=PropertyAccess.READ)
+    def Bar(self) -> 's':
+        return self._bar
 
 
 @pytest.mark.asyncio
@@ -74,3 +90,52 @@ async def test_peer_interface():
 
     assert reply.message_type == MessageType.METHOD_RETURN, reply.body[0]
     assert reply.signature == 's'
+
+
+@pytest.mark.asyncio
+async def test_object_manager():
+    expected_reply = {'/test/path/deeper': {
+        'test.interface2': {'Bar': Variant('s', 'str'), 'Foo': Variant('y', 42)}
+    }}
+    reply_ext = {'/test/path': {
+        'test.interface1': {},
+        'test.interface2': {'Bar': Variant('s', 'str'), 'Foo': Variant('y', 42)}
+    }}
+
+    bus1 = await MessageBus().connect()
+    bus2 = await MessageBus().connect()
+
+    interface = ExampleInterface('test.interface1')
+    interface2 = ExampleComplexInterface('test.interface2')
+
+    export_path = '/test/path'
+    bus1.export(export_path, interface)
+    bus1.export(export_path, interface2)
+    bus1.export(export_path+'/deeper', interface2)
+
+    reply_root = await bus2.call(
+        Message(destination=bus1.unique_name,
+                path='/',
+                interface='org.freedesktop.DBus.ObjectManager',
+                member='GetManagedObjects'))
+
+    reply_level1 = await bus2.call(
+        Message(destination=bus1.unique_name,
+                path=export_path,
+                interface='org.freedesktop.DBus.ObjectManager',
+                member='GetManagedObjects'))
+
+    reply_level2 = await bus2.call(
+        Message(destination=bus1.unique_name,
+                path=export_path+'/deeper',
+                interface='org.freedesktop.DBus.ObjectManager',
+                member='GetManagedObjects'))
+
+    assert reply_root.signature == 'a{oa{sa{sv}}}'
+    assert reply_level1.signature == 'a{oa{sa{sv}}}'
+    assert reply_level2.signature == 'a{oa{sa{sv}}}'
+
+    assert reply_level2.body == [{}]
+    assert reply_level1.body == [expected_reply]
+    expected_reply.update(reply_ext)
+    assert reply_root.body == [expected_reply]

--- a/test/service/test_standard_interfaces.py
+++ b/test/service/test_standard_interfaces.py
@@ -94,13 +94,23 @@ async def test_peer_interface():
 
 @pytest.mark.asyncio
 async def test_object_manager():
-    expected_reply = {'/test/path/deeper': {
-        'test.interface2': {'Bar': Variant('s', 'str'), 'Foo': Variant('y', 42)}
-    }}
-    reply_ext = {'/test/path': {
-        'test.interface1': {},
-        'test.interface2': {'Bar': Variant('s', 'str'), 'Foo': Variant('y', 42)}
-    }}
+    expected_reply = {
+        '/test/path/deeper': {
+            'test.interface2': {
+                'Bar': Variant('s', 'str'),
+                'Foo': Variant('y', 42)
+            }
+        }
+    }
+    reply_ext = {
+        '/test/path': {
+            'test.interface1': {},
+            'test.interface2': {
+                'Bar': Variant('s', 'str'),
+                'Foo': Variant('y', 42)
+            }
+        }
+    }
 
     bus1 = await MessageBus().connect()
     bus2 = await MessageBus().connect()
@@ -111,7 +121,7 @@ async def test_object_manager():
     export_path = '/test/path'
     bus1.export(export_path, interface)
     bus1.export(export_path, interface2)
-    bus1.export(export_path+'/deeper', interface2)
+    bus1.export(export_path + '/deeper', interface2)
 
     reply_root = await bus2.call(
         Message(destination=bus1.unique_name,
@@ -127,7 +137,7 @@ async def test_object_manager():
 
     reply_level2 = await bus2.call(
         Message(destination=bus1.unique_name,
-                path=export_path+'/deeper',
+                path=export_path + '/deeper',
                 interface='org.freedesktop.DBus.ObjectManager',
                 member='GetManagedObjects'))
 


### PR DESCRIPTION
This patch adds `org.freedesktop.DBus.ObjectManager` interface to the default interfaces of the Node.

The interface implements `GetManagedObjects` method and it exposes `InterfacesAdded` and `InterfacesRemoved` although it doesn't implement automatic signal emission.

In addition this patch adds option to select the way introspection is presented. If `expanded_intr` option is True (False by default) the interface tree in introspection will be expanded i.e:
> `/` 
`/com`
`/com/example`
`/com/example/sample0`

else introspection is presented as before:
> `/com/example/sample0`