### PR TITLE
Change absolute paths to relative paths.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,9 +38,9 @@ While other libraries for DBus exist for Python, this library offers the followi
 
 The library offers three core interfaces:
 
-- `The High Level Client </high-level-client/index.html>`_ - Communicate with an existing interface exported on the bus by another client through a proxy object.
-- `The High Level Service </high-level-service/index.html>`_ - Export a service interface for your application other clients can connect to for interaction with your application at runtime.
-- `The Low Level Interface </low-level-interface/index.html>`_ - Work with DBus messages directly for applications that work with the DBus daemon directly or to build your own high level abstractions.
+- `The High Level Client <high-level-client/index.html>`_ - Communicate with an existing interface exported on the bus by another client through a proxy object.
+- `The High Level Service <high-level-service/index.html>`_ - Export a service interface for your application other clients can connect to for interaction with your application at runtime.
+- `The Low Level Interface <low-level-interface/index.html>`_ - Work with DBus messages directly for applications that work with the DBus daemon directly or to build your own high level abstractions.
 
 Installation
 ++++++++++++


### PR DESCRIPTION
I noticed that the links in the list of core interfaces on [readthedocs](https://python-dbus-next.readthedocs.io/en/latest/index.html) are broken.
This was caused by the use of absolute paths in the link target. I changed the paths to relative ones. 