### PR TITLE
Fix code snippets on readthedocs

### DIFF
--- a/dbus_next/aio/proxy_object.py
+++ b/dbus_next/aio/proxy_object.py
@@ -27,7 +27,7 @@ class ProxyInterface(BaseProxyInterface):
 
     A *method call* takes this form:
 
-    .. code-block::
+    .. code-block:: python3
 
         result = await interface.call_[METHOD](*args)
 
@@ -40,7 +40,7 @@ class ProxyInterface(BaseProxyInterface):
 
     To *listen to a signal* use this form:
 
-    .. code-block::
+    .. code-block:: python3
 
         interface.on_[SIGNAL](callback)
 
@@ -52,7 +52,7 @@ class ProxyInterface(BaseProxyInterface):
 
     To *get or set a property* use this form:
 
-    .. code-block::
+    .. code-block:: python3
 
         value = await interface.get_[PROPERTY]()
         await interface.set_[PROPERTY](value)

--- a/dbus_next/glib/proxy_object.py
+++ b/dbus_next/glib/proxy_object.py
@@ -33,7 +33,7 @@ class ProxyInterface(BaseProxyInterface):
 
     A *method call* takes this form:
 
-    .. code-block::
+    .. code-block:: python3
 
         def callback(error: Exception, result: list(Any)):
             pass
@@ -61,7 +61,7 @@ class ProxyInterface(BaseProxyInterface):
 
     To *listen to a signal* use this form:
 
-    .. code-block::
+    .. code-block:: python3
 
         interface.on_[SIGNAL](callback)
 
@@ -73,7 +73,7 @@ class ProxyInterface(BaseProxyInterface):
 
     To *get or set a property* use this form:
 
-    .. code-block::
+    .. code-block:: python3
 
         def get_callback(error: Exception, value: Any):
             pass


### PR DESCRIPTION
The current documentation on readthedocs is not showing code snippets on the pages for [aio.ProxyInterface](https://python-dbus-next.readthedocs.io/en/latest/high-level-client/aio-proxy-interface.html) and [glib.ProxyInterface](https://python-dbus-next.readthedocs.io/en/latest/high-level-client/glib-proxy-interface.html). A quick look in the [build log](https://readthedocs.org/projects/python-dbus-next/builds/10084910/) showed that for each `code-block::` the highlighting language needs to be specified.

```
/home/docs/checkouts/readthedocs.org/user_builds/python-dbus-next/checkouts/latest/dbus_next/aio/proxy_object.py:docstring of dbus_next.aio.ProxyInterface:17: WARNING: Error in "code-block" directive:
1 argument(s) required, 0 supplied.

.. code-block::

    result = await interface.call_[METHOD](*args)
```

So I added `python3` to the ones that where missing a language specification.