### PR TITLE
Object manager signals

### DIFF
--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -7,6 +7,7 @@ from .errors import DBusError, InvalidAddressError
 from .signature import Variant
 from .proxy_object import BaseProxyObject
 from . import introspection as intr
+from contextlib import suppress
 
 import inspect
 import traceback
@@ -198,11 +199,12 @@ class BaseMessageBus:
         :type interface: :class:`ServiceInterface
             <dbus_next.service.ServiceInterface>`
         """
-        body = {
-            interface.name: {
-                prop.name: Variant(prop.signature, prop.prop_getter(interface))
-            for prop in interface._get_properties(interface)}
-        }
+        body = {interface.name: {}}
+        properties = interface._get_properties(interface)
+
+        for prop in properties:
+            with suppress(Exception):
+                body[interface.name][prop.name] = Variant(prop.signature, prop.prop_getter(interface))
 
         self.send(
             Message.new_signal(path=path,

--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -99,7 +99,7 @@ class BaseMessageBus:
 
         self._path_exports[path].append(interface)
         ServiceInterface._add_bus(interface, self)
-        self.emit_interface_added(path, interface)
+        self._emit_interface_added(path, interface)
 
     def unexport(self, path: str, interface: Optional[Union[ServiceInterface, str]] = None):
         """Unexport the path or service interface to make it no longer
@@ -146,7 +146,7 @@ class BaseMessageBus:
                     if not self._has_interface(iface):
                         ServiceInterface._remove_bus(iface, self)
                     break
-        self.emit_interface_removed(path, removed_interfaces)
+        self._emit_interface_removed(path, removed_interfaces)
 
     def introspect(self, bus_name: str, path: str,
                    callback: Callable[[Optional[intr.Node], Optional[Exception]], None]):
@@ -186,7 +186,7 @@ class BaseMessageBus:
                     interface='org.freedesktop.DBus.Introspectable',
                     member='Introspect'), reply_notify)
 
-    def emit_interface_added(self, path, interface):
+    def _emit_interface_added(self, path, interface):
         """Emit the ``org.freedesktop.DBus.ObjectManager.InterfacesAdded`` signal.
 
         This signal is intended to be used to alert clients when
@@ -211,7 +211,7 @@ class BaseMessageBus:
                                signature='oa{sa{sv}}',
                                body=[path, body]))
 
-    def emit_interface_removed(self, path, removed_interfaces):
+    def _emit_interface_removed(self, path, removed_interfaces):
         """Emit the ``org.freedesktop.DBus.ObjectManager.InterfacesRemoved` signal.
 
         This signal is intended to be used to alert clients when

--- a/dbus_next/signature.py
+++ b/dbus_next/signature.py
@@ -386,3 +386,6 @@ class Variant:
             return self.signature == other.signature and self.value == other.value
         else:
             return super().__eq__(other)
+
+    def __repr__(self):
+        return "<dbus_next.signature.Variant ('%s', %s)>" % (self.type.signature, self.value)

--- a/test/client/test_signals.py
+++ b/test/client/test_signals.py
@@ -63,6 +63,8 @@ async def test_signals():
         except Exception as e:
             err = e
 
+    await ping()
+
     interface.on_some_signal(single_handler)
     interface.on_signal_multiple(multiple_handler)
 

--- a/test/service/test_signals.py
+++ b/test/service/test_signals.py
@@ -35,6 +35,23 @@ class ExampleInterface(ServiceInterface):
     def signal_disabled(self):
         assert type(self) is ExampleInterface
 
+    @dbus_property(access=PropertyAccess.READ)
+    def test_prop(self) -> 'i':
+        return 42
+
+
+class SecondExampleInterface(ServiceInterface):
+    def __init__(self, name):
+        super().__init__(name)
+
+    @dbus_property(access=PropertyAccess.READ)
+    def str_prop(self) -> 's':
+        return "abc"
+
+    @dbus_property(access=PropertyAccess.READ)
+    def list_prop(self) -> 'ai':
+        return [1, 2, 3]
+
 
 class ExpectMessage:
     def __init__(self, bus1, bus2, timeout=1):
@@ -142,3 +159,78 @@ async def test_signals():
 
     with pytest.raises(SignalDisabledError):
         interface.signal_disabled()
+
+
+@pytest.mark.asyncio
+async def test_interface_add_remove_signal():
+    bus1 = await MessageBus().connect()
+    bus2 = await MessageBus().connect()
+
+    await bus2.call(
+        Message(destination='org.freedesktop.DBus',
+                path='/org/freedesktop/DBus',
+                interface='org.freedesktop.DBus',
+                member='AddMatch',
+                signature='s',
+                body=[f'sender={bus1.unique_name}']))
+
+    first_interface = ExampleInterface('test.interface.first')
+    second_interface = SecondExampleInterface('test.interface.second')
+    export_path = '/test/path'
+
+    # add first interface
+    async with ExpectMessage(bus1, bus2) as expected_signal:
+        bus1.export(export_path, first_interface)
+        assert_signal_ok(
+            signal=await expected_signal,
+            interface_name='org.freedesktop.DBus.ObjectManager',
+            export_path=export_path,
+            unique_name=bus1.unique_name,
+            member='InterfacesAdded',
+            signature='oa{sa{sv}}',
+            body=[export_path, {'test.interface.first': {'test_prop': Variant('i', 42)}}]
+        )
+
+    # add second interface
+    async with ExpectMessage(bus1, bus2) as expected_signal:
+        bus1.export(export_path, second_interface)
+        assert_signal_ok(
+            signal=await expected_signal,
+            interface_name='org.freedesktop.DBus.ObjectManager',
+            export_path=export_path,
+            unique_name=bus1.unique_name,
+            member='InterfacesAdded',
+            signature='oa{sa{sv}}',
+            body=[export_path,
+                  {'test.interface.second': {'str_prop': Variant('s', "abc"), 'list_prop': Variant('ai', [1, 2, 3])}}]
+        )
+
+    # remove single interface
+    async with ExpectMessage(bus1, bus2) as expected_signal:
+        bus1.unexport(export_path, second_interface)
+        assert_signal_ok(
+            signal=await expected_signal,
+            interface_name='org.freedesktop.DBus.ObjectManager',
+            export_path=export_path,
+            unique_name=bus1.unique_name,
+            member='InterfacesRemoved',
+            signature='oas',
+            body=[export_path, ['test.interface.second']]
+        )
+
+    # add second interface again
+    async with ExpectMessage(bus1, bus2):
+        bus1.export(export_path, second_interface)
+
+    # remove multiple interfaces
+    async with ExpectMessage(bus1, bus2) as expected_signal:
+        bus1.unexport(export_path)
+        assert_signal_ok(
+            signal=await expected_signal,
+            interface_name='org.freedesktop.DBus.ObjectManager',
+            export_path=export_path,
+            unique_name=bus1.unique_name,
+            member='InterfacesRemoved',
+            signature='oas',
+            body=[export_path, ['test.interface.first', 'test.interface.second']]
+        )

--- a/test/service/test_signals.py
+++ b/test/service/test_signals.py
@@ -1,6 +1,9 @@
-from dbus_next.service import ServiceInterface, signal, SignalDisabledError
+from dbus_next.service import ServiceInterface, signal, SignalDisabledError, dbus_property
 from dbus_next.aio import MessageBus
 from dbus_next import Message, MessageType
+from dbus_next.constants import PropertyAccess
+from dbus_next.signature import Variant
+
 
 import pytest
 import asyncio
@@ -33,6 +36,45 @@ class ExampleInterface(ServiceInterface):
         assert type(self) is ExampleInterface
 
 
+class ExpectMessage:
+    def __init__(self, bus1, bus2, timeout=1):
+        self.future = asyncio.get_event_loop().create_future()
+        self.bus1 = bus1
+        self.bus2 = bus2
+        self.timeout = timeout
+        self.timeout_task = None
+
+    def message_handler(self, msg):
+        self.timeout_task.cancel()
+        self.bus2.remove_message_handler(self.message_handler)
+        self.future.set_result(msg)
+        return True
+
+    def timeout_cb(self):
+        self.bus2.remove_message_handler(self.message_handler)
+        self.future.set_result(TimeoutError())
+
+    async def __aenter__(self):
+        self.bus2.add_message_handler(self.message_handler)
+        self.timeout_task = asyncio.get_event_loop().call_later(self.timeout, self.timeout_cb)
+
+        return self.future
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+def assert_signal_ok(signal, interface_name, export_path, unique_name, member, signature, body):
+    assert not isinstance(signal, TimeoutError)
+    assert signal.message_type == MessageType.SIGNAL
+    assert signal.interface == interface_name
+    assert signal.path == export_path
+    assert signal.sender == unique_name
+    assert signal.member == member
+    assert signal.signature == signature
+    assert signal.body == body
+
+
 @pytest.mark.asyncio
 async def test_signals():
     bus1 = await MessageBus().connect()
@@ -50,42 +92,53 @@ async def test_signals():
                 signature='s',
                 body=[f'sender={bus1.unique_name}']))
 
-    async def wait_for_message():
-        # TODO timeout
-        future = asyncio.get_event_loop().create_future()
+    async with ExpectMessage(bus1, bus2) as expected_signal:
+        interface.signal_empty()
+        assert_signal_ok(
+            signal=await expected_signal,
+            interface_name=interface.name,
+            export_path=export_path,
+            unique_name=bus1.unique_name,
+            member='signal_empty',
+            signature='',
+            body=[]
+        )
 
-        def message_handler(signal):
-            if signal.sender == bus1.unique_name and signal.interface == interface.name:
-                bus1.remove_message_handler(message_handler)
-                future.set_result(signal)
+    async with ExpectMessage(bus1, bus2) as expected_signal:
+        interface.original_name()
+        assert_signal_ok(
+            signal=await expected_signal,
+            interface_name=interface.name,
+            export_path=export_path,
+            unique_name=bus1.unique_name,
+            member='renamed',
+            signature='',
+            body=[]
+        )
 
-        bus2.add_message_handler(message_handler)
-        return await future
+    async with ExpectMessage(bus1, bus2) as expected_signal:
+        interface.signal_simple()
+        assert_signal_ok(
+            signal=await expected_signal,
+            interface_name=interface.name,
+            export_path=export_path,
+            unique_name=bus1.unique_name,
+            member='signal_simple',
+            signature='s',
+            body=['hello']
+        )
 
-    def assert_signal_ok(signal, member, signature, body):
-        assert signal.message_type == MessageType.SIGNAL, signal.body[0]
-        assert signal.interface == interface.name
-        assert signal.path == export_path
-        assert signal.sender == bus1.unique_name
-        assert signal.member == member
-        assert signal.signature == signature
-        assert signal.body == body
-
-    interface.signal_empty()
-    signal = await wait_for_message()
-    assert_signal_ok(signal, 'signal_empty', '', [])
-
-    interface.original_name()
-    signal = await wait_for_message()
-    assert_signal_ok(signal, 'renamed', '', [])
-
-    interface.signal_simple()
-    signal = await wait_for_message()
-    assert_signal_ok(signal, 'signal_simple', 's', ['hello'])
-
-    interface.signal_multiple()
-    signal = await wait_for_message()
-    assert_signal_ok(signal, 'signal_multiple', 'ss', ['hello', 'world'])
+    async with ExpectMessage(bus1, bus2) as expected_signal:
+        interface.signal_multiple()
+        assert_signal_ok(
+            signal=await expected_signal,
+            interface_name=interface.name,
+            export_path=export_path,
+            unique_name=bus1.unique_name,
+            member='signal_multiple',
+            signature='ss',
+            body=['hello', 'world']
+        )
 
     with pytest.raises(SignalDisabledError):
         interface.signal_disabled()


### PR DESCRIPTION
This patch adds functionality to send InterfacesAdded and InterfacesRemoved signal to ObjectManager.

Additional tests for signals now use reworked observer to catch messages.