### PR TITLE
Fix race condition in examples for high level service interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,11 @@ class ExampleInterface(ServiceInterface):
 
 async def main():
     bus = await MessageBus().connect()
-    await bus.request_name('test.name')
     interface = ExampleInterface('test.interface')
     bus.export('/test/path', interface)
+    # now that we are ready to handle requests, we can request name from D-Bus
+    await bus.request_name('test.name')
+    # wait indefinitely
     await asyncio.get_event_loop().create_future()
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/docs/high-level-service/index.rst
+++ b/docs/high-level-service/index.rst
@@ -77,9 +77,9 @@ After the service interface is defined, call :func:`MessageBus.export() <dbus_ne
 
     async def main():
         bus = await MessageBus().connect()
-        await bus.request_name('com.example.name')
         interface = ExampleInterface()
         bus.export('/com/example/sample0', interface)
+        await bus.request_name('com.example.name')
 
         # emit the changed signal after two seconds.
         await asyncio.sleep(2)

--- a/examples/example-service.py
+++ b/examples/example-service.py
@@ -54,9 +54,9 @@ async def main():
     interface_name = 'example.interface'
 
     bus = await MessageBus().connect()
-    await bus.request_name(name)
     interface = ExampleInterface(interface_name)
     bus.export('/example/path', interface)
+    await bus.request_name(name)
     print(f'service up on name: "{name}", path: "{path}", interface: "{interface_name}"')
     await asyncio.get_event_loop().create_future()
 


### PR DESCRIPTION
If we first `request_name` and then `bus.export` our service
then there is a (short) period of time when we already own the name
but our MessageBus class doesn't know which services shall it provide.
As a result, if we get a request in this period of time,
we will reply with an error "SERVICE.METHOD with signature SIGNATURE not found".

This situation will happen regularly if we are started by dbus-daemon
because we were declared in the `.service` file. For example:

```
[D-BUS Service]
Name=test.name
Exec=/path/to/my/service.py
```

With the old vesion of examples, this will fail to handle the first request
for which D-Bus started our service.