### PR TITLE
Proper cleanup of watches and message handlers

### DIFF
--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -561,17 +561,18 @@ class BaseMessageBus:
                 bus.send(reply)
 
             def __exit__(self, type, value, tb):
-                if issubclass(type, DBusError):
-                    self(value._as_message(msg))
-                    return True
+                if type:
+                    if issubclass(type, DBusError):
+                        self(value._as_message(msg))
+                        return True
 
-                if issubclass(type, Exception):
-                    self(
-                        Message.new_error(
-                            msg, ErrorType.SERVICE_ERROR,
-                            f'The service interface raised an error: {value}.\n{traceback.format_tb(tb)}'
-                        ))
-                    return True
+                    if issubclass(type, Exception):
+                        self(
+                            Message.new_error(
+                                msg, ErrorType.SERVICE_ERROR,
+                                f'The service interface raised an error: {value}.\n{traceback.format_tb(tb)}'
+                            ))
+                        return True
 
         return SendReply()
 


### PR DESCRIPTION
Using this library for running BlueZ discovery for a whole day, I noticed some things were not being cleaned up properly. All interface objects remained in memory until the connection is closed. Instead, they should be cleaned up if nobody references them anymore. When they do get cleaned up, the corresponding message handler and DBus watch should be deleted, to avoid hitting the DBus per-connection watch limit.