### PR TITLE
Allow calling methods with no expected reply

### DIFF
--- a/dbus_next/aio/proxy_object.py
+++ b/dbus_next/aio/proxy_object.py
@@ -1,6 +1,6 @@
 from ..proxy_object import BaseProxyObject, BaseProxyInterface
 from ..message_bus import BaseMessageBus
-from ..message import Message
+from ..message import Message, MessageFlag
 from ..signature import Variant
 from ..errors import DBusError
 from ..constants import ErrorType
@@ -66,14 +66,18 @@ class ProxyInterface(BaseProxyInterface):
     <dbus_next.DBusError>` will be raised with information about the error.
     """
     def _add_method(self, intr_method):
-        async def method_fn(*args):
+        async def method_fn(*args, flags=MessageFlag.NONE):
             msg = await self.bus.call(
                 Message(destination=self.bus_name,
                         path=self.path,
                         interface=self.introspection.name,
                         member=intr_method.name,
                         signature=intr_method.in_signature,
-                        body=list(args)))
+                        body=list(args),
+                        flags=flags))
+
+            if flags & MessageFlag.NO_REPLY_EXPECTED:
+                return None
 
             BaseProxyInterface._check_method_return(msg, intr_method.out_signature)
 

--- a/test/client/test_methods.py
+++ b/test/client/test_methods.py
@@ -1,3 +1,4 @@
+from dbus_next.message import MessageFlag
 from dbus_next.service import ServiceInterface, method
 import dbus_next.introspection as intr
 from dbus_next import aio, glib, DBusError
@@ -74,6 +75,9 @@ async def test_aio_proxy_object():
 
     result = await interface.call_echo_int64(-10000)
     assert result == -10000
+
+    result = await interface.call_echo_string('no reply', flags=MessageFlag.NO_REPLY_EXPECTED)
+    assert result is None
 
     with pytest.raises(DBusError):
         try:


### PR DESCRIPTION
Some services expose interfaces that don't send method call replies. This PR allows python-dbus-next to mark method call with NO_REPLY_EXPECTED flag.

Without this, calling such methods results in a warning in logs:

```
2020-07-10 10:28:57 root                                     ERROR     message_bus.py:573  got unexpected error processing a message: invalid state.
Traceback (most recent call last):
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/message_bus.py", line 570, in _on_message
    self._process_message(msg)
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/message_bus.py", line 668, in _process_message
    handler(msg, None)
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/message_bus.py", line 535, in reply_notify
    callback(reply, err)
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/aio/message_bus.py", line 217, in reply_handler
    future.set_result(reply)
asyncio.base_futures.InvalidStateError: invalid state
```