### PR TITLE
Fix unmarshaller prefetch align

### DIFF
--- a/dbus_next/_private/unmarshaller.py
+++ b/dbus_next/_private/unmarshaller.py
@@ -228,7 +228,8 @@ class Unmarshaller:
         serial = self.read_uint32()
 
         header_len = self.read_uint32()
-        self.read(header_len + body_len, prefetch=True)
+        msg_len = header_len + self._padding(header_len, 8) + body_len
+        self.read(msg_len, prefetch=True)
         # backtrack offset since header array length needs to be read again
         self.offset -= 4
 

--- a/dbus_next/_private/unmarshaller.py
+++ b/dbus_next/_private/unmarshaller.py
@@ -71,11 +71,30 @@ class Unmarshaller:
             self.offset += n
         return prev
 
+    @staticmethod
+    def _padding(offset, align):
+        """
+        Get padding bytes to get to the next align bytes mark.
+
+        For any align value, the correct padding formula is:
+
+            (align - (offset % align)) % align
+
+        However, if align is a power of 2 (always the case here), the slow MOD
+        operator can be replaced by a bitwise AND:
+
+            (align - (offset & (align - 1))) & (align - 1)
+
+        Which can be simplified to:
+
+            (-offset) & (align - 1)
+        """
+        return (-offset) & (align - 1)
+
     def align(self, n):
-        padding = n - self.offset % n
-        if padding == 0 or padding == n:
-            return
-        self.read(padding)
+        padding = self._padding(self.offset, n)
+        if padding > 0:
+            self.read(padding)
 
     def read_byte(self, _=None):
         return self.buf[self.read(1)]


### PR DESCRIPTION
When the message header is not a multiple of 8 bytes long, there will be an additional read performed when reading the body since there is an alignment after reading the header. I forgot to take this into account in #62.

I also added a small optimization in padding computing since I needed a separate function to get header padding.