### PR TITLE
Include py.typed in Manifest.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.md LICENSE CHANGELOG.md pytest.ini requirements.txt .flake8 .style.yapf Dockerfile
+include README.md LICENSE CHANGELOG.md pytest.ini requirements.txt .flake8 .style.yapf Dockerfile dbus_next/py.typed
 recursive-include test *.py


### PR DESCRIPTION
py.typed needs to be included in package otherwise mypy will
throw out errors.