### PR TITLE
Bug fix in property validation error message

### DIFF
--- a/dbus_next/service.py
+++ b/dbus_next/service.py
@@ -354,7 +354,7 @@ class ServiceInterface:
         # validate that writable properties have a setter
         for prop in self.__properties:
             if prop.access.writable() and prop.prop_setter is None:
-                raise ValueError(f'property "{member.name}" is writable but does not have a setter')
+                raise ValueError(f'property "{prop.name}" is writable but does not have a setter')
 
     def emit_properties_changed(self,
                                 changed_properties: Dict[str, Any],


### PR DESCRIPTION
 #### Issue
  * `member` is undefined here and triggers an AttributeError, causing
  user to miss the actual error message.

 #### Fix
  * Replace `member` with `prop`. Tested by creating a RW property
  without a setter and got the correct error message:
  ```
  ValueError: property "MyProp" is writable but does not have a setter
  ```