### PR TITLE
Don't log errors if call failed after disconnect

### DIFF
--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -962,6 +962,9 @@ class BaseMessageBus:
         del self._match_rules[match_rule]
 
         def remove_match_notify(msg, err):
+            if self._disconnected:
+                return
+
             if err:
                 logging.error(f'remove match request failed. match="{match_rule}", {err}')
             if msg.message_type == MessageType.ERROR:


### PR DESCRIPTION
This gets rid of unnecessary log after disconnect:
```
 ERROR remove match request failed. match="type='signal',sender=org.freedesktop.DBus,interface=org.freedesktop.DBus,path=/org/freedesktop/DBus",
WARNING a message handler threw an exception on shutdown
Traceback (most recent call last):
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/aio/message_bus.py", line 366, in _message_reader
    if self._unmarshaller.unmarshall():
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/_private/unmarshaller.py", line 304, in unmarshall
    self._unmarshall()
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/_private/unmarshaller.py", line 243, in _unmarshall
    self.read(16, prefetch=True)
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/_private/unmarshaller.py", line 91, in read
    raise EOFError()
EOFError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/message_bus.py", line 451, in _finalize
    handler(None, err)
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/message_bus.py", line 580, in reply_notify
    callback(reply, err)
  File "/home/khorne/Programming/silvair/python-dbus-next/dbus_next/message_bus.py", line 967, in remove_match_notify
    if msg.message_type == MessageType.ERROR:
AttributeError: 'NoneType' object has no attribute 'message_type'
```