### PR TITLE
update the re pattern for valid name assertion

### DIFF
--- a/dbus_next/validators.py
+++ b/dbus_next/validators.py
@@ -4,6 +4,7 @@ from .errors import InvalidBusNameError, InvalidObjectPathError, InvalidInterfac
 _bus_name_re = re.compile(r'^[A-Za-z_-][A-Za-z0-9_-]*$')
 _path_re = re.compile(r'^[A-Za-z0-9_]+$')
 _element_re = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+_member_re = re.compile(r'^[A-Za-z_][A-Za-z0-9_-]*$')
 
 
 def is_bus_name_valid(name: str) -> bool:
@@ -117,7 +118,7 @@ def is_member_name_valid(member: str) -> bool:
     if not member or len(member) > 255:
         return False
 
-    if _element_re.search(member) is None:
+    if _member_re.search(member) is None:
         return False
 
     return True

--- a/test/test_validators.py
+++ b/test/test_validators.py
@@ -43,7 +43,7 @@ def test_interface_name_validator():
 
 
 def test_member_name_validator():
-    valid_members = ['foo', 'FooBar', 'Bat_Baz69']
+    valid_members = ['foo', 'FooBar', 'Bat_Baz69', 'foo-bar']
     invalid_members = [None, {}, '', 'foo.bar', '5foo', 'foo$bar']
 
     for member in valid_members:


### PR DESCRIPTION
For gtk application(tested with Gtk-3.0), generally the registered dbus interface include snippet like this:

    <interface name="org.gtk.Application">
    <method name="Activate">
      <arg type="a{sv}" name="platform-data" direction="in">
      </arg>
    </method>

Currently the member name is matched with the pattern in validators.py:

_element_re = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')

For which name with dash like platform-data will be invalid, the pattern need to be update to support gtk application