### PR TITLE
In docs: signal handlers MUST specify signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ async def main():
     await player.set_volume(0.5)
 
     # listen to signals
-    def on_properties_changed(interface_name, changed_properties, invalidated_properties):
+    def on_properties_changed(interface_name: 's', changed_properties: '{sv}', invalidated_properties: 'as'):
         for changed, variant in changed_properties.items():
             print(f'property changed: {changed} - {variant.value}')
 


### PR DESCRIPTION
In **Client Interface**, signal handlers must specify the signature.
This can be confirmed in `proxy_object.BaseProxyInterface:_addSignal` decorator.

    def on_signal_fn(fn):
            fn_signature = inspect.signature(fn)
            if not callable(fn) or len(fn_signature.parameters) != len(intr_signal.args):
                raise TypeError(

So if the signal handlers doesn't contain a matching signature then a `TypeError` is supposed to be thrown. My experience: never saw a `TypeError` get thrown! 

Therefore, without looking at the source code, there is no way to know why normal signals aren't being triggered.

For example,

    def on_signal_simple(str_hello):
        print(f"{str_hello} world")

Will never be triggered.

    def on_signal_simple(str_hello: 's'):
        print(f"{str_hello} world")

Will get triggered.

`on_property_changed` actually **does get triggered**! Even without the signature. Which only indicates that `org.freedesktop.DBus.Properties.PropertyChanged` signal handling is handled separately.

Please update the misleading Client Interface documentation, so signal handling is intuitive.