### PR TITLE
Check for mismatched signal handler arg annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ async def main():
     await player.set_volume(0.5)
 
     # listen to signals
-    def on_properties_changed(interface_name, changed_properties, invalidated_properties):
+    def on_properties_changed(interface_name: 's', changed_properties: '{sv}', invalidated_properties: 'as'):
         for changed, variant in changed_properties.items():
             print(f'property changed: {changed} - {variant.value}')
 

--- a/dbus_next/__init__.py
+++ b/dbus_next/__init__.py
@@ -6,7 +6,7 @@ from .errors import (SignatureBodyMismatchError, InvalidSignatureError, InvalidA
                      AuthError, InvalidMessageError, InvalidIntrospectionError,
                      InterfaceNotFoundError, SignalDisabledError, InvalidBusNameError,
                      InvalidObjectPathError, InvalidInterfaceNameError, InvalidMemberNameError,
-                     DBusError)
+                     AnnotationMismatchError, DBusError)
 from . import introspection
 from .message import Message
 from . import message_bus

--- a/dbus_next/errors.py
+++ b/dbus_next/errors.py
@@ -50,6 +50,10 @@ class InvalidMemberNameError(TypeError):
         super().__init__(f'invalid member name: {member}')
 
 
+class AnnotationMismatchError(TypeError):
+    def __init__(self, msg):
+        super().__init__(f'In signal handler, there is, one or more, mismatch of arg annotation: {msg}')
+
 from .message import Message
 from .validators import assert_interface_name_valid
 from .constants import ErrorType, MessageType

--- a/dbus_next/proxy_object.py
+++ b/dbus_next/proxy_object.py
@@ -116,7 +116,7 @@ class BaseProxyInterface:
                     err_msg_verbose = f'arg({index}) annotation, {left_side_name}:"{left_side_annotation}" does not match return annotation "{right_side_annotation}"'
                     arr_arg_signature_mismatch.append(err_msg_verbose)
         if len(arr_arg_signature_mismatch)!=0:
-            str_annotation_mismatch = 'In signal handler "{fn_name}", {}'.format('. '.join(arr_arg_signature_mismatch))
+            str_annotation_mismatch = 'In signal handler "{}", {}'.format(fn_name, '. '.join(arr_arg_signature_mismatch))
             raise AnnotationMismatchError(str_annotation_mismatch)
 
     def _add_method(self, intr_method):

--- a/dbus_next/proxy_object.py
+++ b/dbus_next/proxy_object.py
@@ -114,7 +114,7 @@ class BaseProxyInterface:
                 right_side_type = right_side.type
                 if left_side_annotation != right_side_annotation:
                     err_msg_verbose = f'arg({index}) annotation, {left_side_name}:"{left_side_annotation}" does not match return annotation "{right_side_annotation}"'
-                    arr_arg_signature_mismatch.append(err_msg_terse)
+                    arr_arg_signature_mismatch.append(err_msg_verbose)
         if len(arr_arg_signature_mismatch)!=0:
             str_annotation_mismatch = 'In signal handler "{fn_name}", {}'.format('. '.join(arr_arg_signature_mismatch))
             raise AnnotationMismatchError(str_annotation_mismatch)

--- a/test/client/test_signals_check_arg_annotation.py
+++ b/test/client/test_signals_check_arg_annotation.py
@@ -1,0 +1,135 @@
+from dbus_next.service import ServiceInterface, signal
+from dbus_next.aio import MessageBus
+from dbus_next import Message
+from dbus_next.introspection import Node
+from dbus_next.constants import RequestNameReply
+from dbus_next.error import AnnotationMismatchError
+
+import pytest
+
+
+class ExampleInterface(ServiceInterface):
+    def __init__(self):
+        super().__init__('test.interface')
+
+    @signal()
+    def SomeSignal(self) -> 's':
+        return 'hello'
+
+    @signal()
+    def SignalMultiple(self) -> 'ss':
+        return ['hello', 'world']
+
+
+@pytest.mark.asyncio
+async def test_signals_check_arg_annotation():
+    bus1 = await MessageBus().connect()
+    bus2 = await MessageBus().connect()
+
+    bus_intr = await bus1.introspect('org.freedesktop.DBus', '/org/freedesktop/DBus')
+    bus_obj = bus1.get_proxy_object('org.freedesktop.DBus', '/org/freedesktop/DBus', bus_intr)
+    stats = bus_obj.get_interface('org.freedesktop.DBus.Debug.Stats')
+
+    await bus1.request_name('test.signals.name')
+    service_interface = ExampleInterface()
+    bus1.export('/test/path', service_interface)
+
+    obj = bus2.get_proxy_object('test.signals.name', '/test/path',
+                                bus1._introspect_export_path('/test/path'))
+    interface = obj.get_interface(service_interface.name)
+
+    async def ping():
+        await bus2.call(
+            Message(destination=bus1.unique_name,
+                    interface='org.freedesktop.DBus.Peer',
+                    path='/test/path',
+                    member='Ping'))
+
+    err_correct_annotation = None
+    err_wrong_annotation = None
+    err_no_annotation = None
+    err_multiple_mixed_correct_annotation = None
+    err_multiple_mixed_wrong_annotation = None
+    
+    single_counter = 0
+    multiple_counter = 0
+
+    def single_handler_correct_annotation(value: 's'):
+        try:
+            nonlocal single_counter
+            nonlocal err_correct_annotation
+            assert value == 'hello'
+            single_counter += 1
+        except Exception as e:
+            err_correct_annotation = e
+
+    def single_handler_wrong_annotation(value: 'b'):
+        try:
+            nonlocal single_counter
+            nonlocal err_wrong_annotation
+            assert value == 'hello'
+            single_counter += 1
+        except Exception as e:
+            err_wrong_annotation = e
+
+    def single_handler_no_annotation(value):
+        try:
+            nonlocal single_counter
+            nonlocal err_no_annotation
+            assert value == 'hello'
+            single_counter += 1
+        except Exception as e:
+            err_no_annotation = e
+
+    def multiple_handler_mixed_correct_annotation(value1:'s', value2):
+        nonlocal multiple_counter
+        nonlocal err_multiple_mixed_correct_annotation
+        try:
+            assert value1 == 'hello'
+            assert value2 == 'world'
+            multiple_counter += 1
+        except Exception as e:
+            err_multiple_mixed_correct_annotation = e
+
+    def multiple_handler_mixed_wrong_annotation(value1:'b', value2):
+        nonlocal multiple_counter
+        nonlocal err_multiple_mixed_wrong_annotation
+        try:
+            assert value1 == 'hello'
+            assert value2 == 'world'
+            multiple_counter += 1
+        except Exception as e:
+            err_multiple_mixed_wrong_annotation = e
+            
+    
+    await ping()
+
+    interface.on_some_signal(single_handler_correct_annotation)
+    interface.on_some_signal(single_handler_wrong_annotation)
+    interface.on_some_signal(single_handler_no_annotation)
+    
+    interface.on_signal_multiple(multiple_handler_mixed_correct_annotation)
+    interface.on_signal_multiple(multiple_handler_mixed_wrong_annotation)
+
+    service_interface.SomeSignal()
+    await ping()
+    assert err_correct_annotation is None
+    assert err_wrong_annotation is AnnotationMismatchError
+    assert err_no_annotation is None
+    assert single_counter == 3
+
+    service_interface.SignalMultiple()
+    await ping()
+    assert err_multiple_mixed_correct_annotation is None
+    assert err_multiple_mixed_wrong_annotation is AnnotationMismatchError
+    assert multiple_counter == 2
+
+    interface.off_some_signal(single_handler_correct_annotation)
+    interface.off_some_signal(single_handler_wrong_annotation)
+    interface.off_some_signal(single_handler_no_annotation)
+    interface.off_signal_multiple(multiple_handler_mixed_correct_annotation)
+    interface.off_signal_multiple(multiple_handler_mixed_wrong_annotation)
+    
+    bus1.disconnect()
+    bus2.disconnect()
+


### PR DESCRIPTION
Both test and fix provided

Introduces a new Exception, AnnotationMismatchError

This Exception occurs only when:

- signal handler arg annotation IS provided
- signal handler arg annotation and signal return arg annotation are mismatched

The point is to be informative (to Client developer), not to be strict.

A Client developer can be mistaken on what arg type to expect. The Exception message will help the Client developer pinpoint exactly which signal handler, arg, and what is the correct annotation for that arg. So as to quickly resolve the mismatch.