### PR TITLE
Make bus_name optional for proxy object

### DIFF
--- a/dbus_next/aio/message_bus.py
+++ b/dbus_next/aio/message_bus.py
@@ -326,7 +326,8 @@ class MessageBus(BaseMessageBus):
         self._writer.schedule_write(msg, future)
         return future
 
-    def get_proxy_object(self, bus_name: str, path: str, introspection: intr.Node) -> ProxyObject:
+    def get_proxy_object(self, bus_name: Optional[str], path: str,
+                         introspection: intr.Node) -> ProxyObject:
         return super().get_proxy_object(bus_name, path, introspection)
 
     async def wait_for_disconnect(self):

--- a/dbus_next/glib/message_bus.py
+++ b/dbus_next/glib/message_bus.py
@@ -433,7 +433,8 @@ class MessageBus(BaseMessageBus):
         if self.unique_name:
             self._schedule_write()
 
-    def get_proxy_object(self, bus_name: str, path: str, introspection: intr.Node) -> ProxyObject:
+    def get_proxy_object(self, bus_name: Optional[str], path: str,
+                         introspection: intr.Node) -> ProxyObject:
         return super().get_proxy_object(bus_name, path, introspection)
 
     def _schedule_write(self):

--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -347,7 +347,7 @@ class BaseMessageBus:
                     signature='s',
                     body=[name]), reply_notify if callback else None)
 
-    def get_proxy_object(self, bus_name: str, path: str,
+    def get_proxy_object(self, bus_name: Optional[str], path: str,
                          introspection: Union[intr.Node, str, ET.Element]) -> BaseProxyObject:
         """Get a proxy object for the path exported on the bus that owns the
         name. The object is expected to export the interfaces and nodes


### PR DESCRIPTION
Some applications send signals without well defined senders, as such the bus_name parameter needs to be made optional in order for us to receive these messages.

Fixes #20, #80