### PR TITLE
Invert proxy object attribute mapping.

### DIFF
--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -15,7 +15,7 @@ import logging
 import xml.etree.ElementTree as ET
 import traceback
 
-from typing import Type, Callable, Optional, Union
+from typing import Type, Callable, Optional, Union, List
 
 
 class BaseMessageBus:
@@ -67,7 +67,7 @@ class BaseMessageBus:
         # high level client only)
         self._name_owners = {}
         # used for the high level service
-        self._path_exports = {}
+        self._path_exports: dict[str, List[ServiceInterface]] = {}
         self._bus_address = parse_address(bus_address) if bus_address else parse_address(
             get_bus_address(bus_type))
         # the bus implementations need this rule for the high level client to


### PR DESCRIPTION
This is an experiment to see if the translation between functions and dbus methods/props/signals can be inverted(seems to work). This technique should in theory be able to be extended to allow receiving signals without introspection(I think).

This also should allow the methods to be loaded on an as needed basis as we now have name based getters in the introspection data structures and can follow those instead of having to preload all introspection data.