### PR TITLE
Fix typo in service example (docs)

### DIFF
--- a/docs/high-level-service/index.rst
+++ b/docs/high-level-service/index.rst
@@ -86,7 +86,7 @@ If any file descriptors are sent or received (DBus type ``h``), the variable ref
         # emit the changed signal after two seconds.
         await asyncio.sleep(2)
 
-        interface.changed()
+        interface.Changed()
 
         await bus.wait_for_disconnect()
 


### PR DESCRIPTION
The example from the docs on the [high-level service interface](https://python-dbus-next.readthedocs.io/en/latest/high-level-service/index.html) currently fails with: 

```python
Traceback (most recent call last):
  File "example.py", line 65, in <module>
    asyncio.get_event_loop().run_until_complete(main())
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "example.py", line 61, in main
    interface.changed()
AttributeError: 'ExampleInterface' object has no attribute 'changed'
```

This fixes the responsible typo.