### PR TITLE
glib: destroy the _AuthLineSource explicitly

### DIFF
--- a/dbus_next/glib/message_bus.py
+++ b/dbus_next/glib/message_bus.py
@@ -457,7 +457,7 @@ class MessageBus(BaseMessageBus):
                 self._stream.write(Authenticator._format_line(resp))
                 self._stream.flush()
                 if resp == 'BEGIN':
-                    self._readline_source = None
+                    self._readline_source.destroy()
                     authenticate_notify(None)
                     return True
             except Exception as e:


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/pygobject/-/issues/525 for an
explanation, the summary is: we need to explicitly call source.destroy()
if dispatch returns GLib.SOURCE_REMOVE.

Deleting the source by resetting it to None causes invalid memory
accesses and eventual crashes.

This can be reproduced with a basic call to
```
    bus = dbus_next.glib.MessageBus(bus_type=dbus_next.BusType.SESSION).connect_sync()
```
and a `GLib.MainLoop()` after this call. Run in `valgrind --tool=memcheck`.

Fixes #113