### PR TITLE
Fix make docker-test by removing python 3.6. Improve docker image build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
     build-essential \
     python3-pip \
     python3 \
-    python3.6 \
     python3.7 \
+    python3.7-distutils \
     python3.9 \
     python3.9-distutils \
     python3.10 \
@@ -26,9 +26,10 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
     dbus \
     python3-gi
 
-RUN pip3 install 'yapf==0.31' 'flake8==4.0.1' && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    for py in python3 python3.6 python3.7 python3.9 python3.10; do \
+RUN set -e -x; \
+    pip3 install 'yapf==0.31' 'flake8==4.0.1'; \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; \
+    for py in python3.7 python3.8 python3.9 python3.10; do \
         ${py} get-pip.py; \
         PYTHONPATH=/usr/lib/${py}/site-packages ${py} -m pip install \
             'pytest==6.2.5' \

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ format:
 	python3 -m yapf -rip $(source_dirs)
 
 test:
-	for py in python3.6 python3.7 python3.9 python3.10 python3.8 ; do \
+	for py in python3.7 python3.9 python3.10 python3.8 ; do \
 		if hash $${py}; then \
 			PYTHONPATH=/usr/lib/$${py}/site-packages dbus-run-session $${py} -m pytest -sv --cov=dbus_next || exit 1 ; \
 		fi \


### PR DESCRIPTION
This fixes the travis ci builds.

python 3.6 is no longer supported[1], and is not longer supported by
get-pip.py [2]

The docker image build is improved by exiting on error inside shell for loop.

[1] https://peps.python.org/pep-0494/
[2] https://pip.pypa.io/en/stable/installation/#compatibility