### PR TITLE
Use enum's constructor to resolve enum values

### DIFF
--- a/dbus_next/_private/constants.py
+++ b/dbus_next/_private/constants.py
@@ -16,6 +16,3 @@ class HeaderField(Enum):
     SENDER = 7
     SIGNATURE = 8
     UNIX_FDS = 9
-
-
-HEADER_NAME_MAP = {field.value: field.name for field in HeaderField}

--- a/dbus_next/_private/unmarshaller.py
+++ b/dbus_next/_private/unmarshaller.py
@@ -5,9 +5,8 @@ from .constants import (
     LITTLE_ENDIAN,
     BIG_ENDIAN,
     PROTOCOL_VERSION,
-    HEADER_NAME_MAP,
 )
-from ..constants import MessageType, MessageFlag, MESSAGE_FLAG_MAP, MESSAGE_TYPE_MAP
+from ..constants import MessageType, MessageFlag
 from ..signature import SignatureTree, SignatureType, Variant
 from ..errors import InvalidMessageError
 
@@ -233,7 +232,7 @@ class Unmarshaller:
             o = self.offset + 1
             self.offset += signature_len + 2  # one for the byte, one for the '\0'
             tree = SignatureTree._get(self.buf[o:o + signature_len].decode())
-            headers[HEADER_NAME_MAP[field_0]] = self.read_argument(tree.types[0])
+            headers[HeaderField(field_0).name] = self.read_argument(tree.types[0])
         return headers
 
     def _read_header(self):
@@ -243,8 +242,8 @@ class Unmarshaller:
         self.read_to_offset(HEADER_SIGNATURE_SIZE)
         buffer = self.buf
         endian = buffer[0]
-        self.message_type = MESSAGE_TYPE_MAP[buffer[1]]
-        self.flag = MESSAGE_FLAG_MAP[buffer[2]]
+        self.message_type = MessageType(buffer[1])
+        self.flag = MessageFlag(buffer[2])
         protocol_version = buffer[3]
 
         if endian != LITTLE_ENDIAN and endian != BIG_ENDIAN:

--- a/dbus_next/constants.py
+++ b/dbus_next/constants.py
@@ -17,9 +17,6 @@ class MessageType(Enum):
     SIGNAL = 4  #: A broadcast signal to subscribed connections
 
 
-MESSAGE_TYPE_MAP = {field.value: field for field in MessageType}
-
-
 class MessageFlag(IntFlag):
     """Flags that affect the behavior of sent and received messages
     """
@@ -27,9 +24,6 @@ class MessageFlag(IntFlag):
     NO_REPLY_EXPECTED = 1  #: The method call does not expect a method return.
     NO_AUTOSTART = 2
     ALLOW_INTERACTIVE_AUTHORIZATION = 4
-
-
-MESSAGE_FLAG_MAP = {field.value: field for field in MessageFlag}
 
 
 class NameFlag(IntFlag):


### PR DESCRIPTION
Rather than creating a map of `{value: enum}`, let's just use `Foo(value)` to resolve to the respective enum value.

This fixes a regression with introspection introduced in commit 3282eed "Improve unmarshall performance":
```
  File "dbus_next/_private/unmarshaller.py", line 247, in _read_header
    self.flag = MESSAGE_FLAG_MAP[buffer[2]]
                ~~~~~~~~~~~~~~~~^^^^^^^^^^^
  KeyError: 0
```
MESSAGE_FLAG_MAP is built like this:
```python
    MESSAGE_FLAG_MAP = {field.value: field for field in MessageFlag}
```

But MessageFlag is a IntFlag, so the zero value (NONE) is missing from the iterator:
```
  >>> [f for f in dbus_next.constants.MessageFlag]
  [<MessageFlag.NO_REPLY_EXPECTED: 1>, <MessageFlag.NO_AUTOSTART: 2>,
   <MessageFlag.ALLOW_INTERACTIVE_AUTHORIZATION: 4>]
```
Resolving the enum through the constructor fixes this. MESSAGE_TYPE_MAP and HEADER_NAME_MAP are changed in solidarity.

Fixes #142 