### PR TITLE
Make client info available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ dmypy.json
 
 # vim
 *.swp
+
+# vscode
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "test"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "test"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -59,7 +59,7 @@ def echo_sender() -> 's':
 Attempts to access any attribute of `current_message` outside of a message context
 will result in a `LookupError` being raised.
 """
-current_message = ContextProxy("current_message")
+current_message = ReadOnlyContextProxy("current_message")
 
 
 class BaseMessageBus:

--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -28,14 +28,14 @@ class ReadOnlyContextProxy:
 
     :param name: The name of the context variable.
     """
-    def __init__(self, name:str):
+    def __init__(self, name: str):
         self._obj = contextvars.ContextVar(name)
 
-    def __getattr__(self, name:str) -> Any:
+    def __getattr__(self, name: str) -> Any:
         proxy = self._obj.get()
         return getattr(proxy, name)
 
-    def set_value(self, value:Any):
+    def set_value(self, value: Any):
         """
         Set the value of the underlying context variable.
         """

--- a/dbus_next/service.py
+++ b/dbus_next/service.py
@@ -88,7 +88,7 @@ def method(name: str = None, disabled: bool = False):
     def decorator(fn):
         @wraps(fn)
         def wrapped(*args, **kwargs):
-            fn(*args, **kwargs)
+            return fn(*args, **kwargs)
 
         fn_name = name if name else fn.__name__
         wrapped.__dict__['__DBUS_METHOD'] = _Method(fn, fn_name, disabled=disabled)

--- a/test/client/test_methods.py
+++ b/test/client/test_methods.py
@@ -42,6 +42,7 @@ class ExampleInterface(ServiceInterface):
     def UsesCurrentMessage(self) -> 's':
         return current_message.sender
 
+
 @pytest.mark.asyncio
 async def test_aio_proxy_object():
     bus_name = 'aio.client.test.methods'
@@ -137,4 +138,3 @@ def test_glib_proxy_object():
 
     bus.disconnect()
     bus2.disconnect()
-

--- a/test/client/test_methods.py
+++ b/test/client/test_methods.py
@@ -2,6 +2,7 @@ from dbus_next.message import MessageFlag
 from dbus_next.service import ServiceInterface, method
 import dbus_next.introspection as intr
 from dbus_next import aio, glib, DBusError
+from dbus_next.message_bus import current_message
 from test.util import check_gi_repository, skip_reason_no_gi
 
 import pytest
@@ -37,6 +38,9 @@ class ExampleInterface(ServiceInterface):
     def ThrowsError(self):
         raise DBusError('test.error', 'something went wrong')
 
+    @method()
+    def UsesCurrentMessage(self) -> 's':
+        return current_message.sender
 
 @pytest.mark.asyncio
 async def test_aio_proxy_object():
@@ -78,6 +82,9 @@ async def test_aio_proxy_object():
 
     result = await interface.call_echo_string('no reply', flags=MessageFlag.NO_REPLY_EXPECTED)
     assert result is None
+
+    result = await interface.call_uses_current_message()
+    assert result
 
     with pytest.raises(DBusError):
         try:
@@ -130,3 +137,4 @@ def test_glib_proxy_object():
 
     bus.disconnect()
     bus2.disconnect()
+

--- a/test/client/test_signals.py
+++ b/test/client/test_signals.py
@@ -3,6 +3,7 @@ from dbus_next.aio import MessageBus
 from dbus_next import Message
 from dbus_next.introspection import Node
 from dbus_next.constants import RequestNameReply
+from dbus_next.message_bus import current_message
 
 import pytest
 
@@ -53,6 +54,7 @@ async def test_signals():
             nonlocal single_counter
             nonlocal err
             assert value == 'hello'
+            assert current_message.sender
             single_counter += 1
         except Exception as e:
             err = e
@@ -65,6 +67,7 @@ async def test_signals():
         try:
             assert value1 == 'hello'
             assert value2 == 'world'
+            assert current_message.sender
             multiple_counter += 1
         except Exception as e:
             err = e

--- a/test/test_tcp_address.py
+++ b/test/test_tcp_address.py
@@ -15,8 +15,12 @@ async def test_tcp_connection_with_forwarding(event_loop):
 
     addr_info = parse_address(os.environ.get('DBUS_SESSION_BUS_ADDRESS'))
     assert addr_info
-    assert 'abstract' in addr_info[0][1]
-    path = f'\0{addr_info[0][1]["abstract"]}'
+    if 'abstract' in addr_info[0][1]:
+        path = f'\0{addr_info[0][1]["abstract"]}'
+    elif 'path' in addr_info[0][1]:
+        path = addr_info[0][1]['path']
+
+    assert path
 
     async def handle_connection(tcp_reader, tcp_writer):
         unix_reader, unix_writer = await asyncio.open_unix_connection(path)


### PR DESCRIPTION
The main change here is to make the `dbus_next.message.Message` object available through the context-local `current_message` proxy.  In client code, the typical usage is:

```
from dbus_next.message_bus import current_message

@method()
def echo_sender() -> 's':
    return current_message.sender
```

A unit test demonstrating this usage is also included.

This also changes the `@method()` decorator so that the method can still be called in a non-dbus context and correctly returns its value.

This also fixes a defect in the unit tests; on my Ubuntu 22.04 system, the default session bus socket is not in the abstract socket namespace.  This caused `test_tcp_connection_with_forwarding` to fail as it assumed that the session bus used a socket in the abstract namespace.  I have modified it to make it work with either an abstract namespace socket or a filesystem socket.