### PR TITLE
Remove valid name check from Property

### DIFF
--- a/dbus_next/introspection.py
+++ b/dbus_next/introspection.py
@@ -239,7 +239,6 @@ class Property:
                  name: str,
                  signature: str,
                  access: PropertyAccess = PropertyAccess.READWRITE):
-        assert_member_name_valid(name)
 
         tree = SignatureTree._get(signature)
         if len(tree.types) != 1:


### PR DESCRIPTION
The [documentation](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-member) states the follow:

> Strictly speaking, D-Bus property names are not required to follow the same naming restrictions as member names, but D-Bus property names that would not be valid member names (in particular, GObject-style dash-separated property names) can cause interoperability problems and should be avoided. 

So it is allowed names, that are not valid member names, but it is a bad prcatice. However, some Interfaces in the Wild using this, that the Lib should be handle.

Fixes #122