### PR TITLE
Close socket on disconnect

### DIFF
--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -386,6 +386,7 @@ class BaseMessageBus:
         self._user_disconnect = True
         try:
             self._sock.shutdown(socket.SHUT_RDWR)
+            self._sock.close()
         except Exception:
             logging.warning('could not shut down socket', exc_info=True)
 


### PR DESCRIPTION
As per issue #137, sockets are not closed when the bus is disconnected. This results in users receiving warnings about unclosed sockets.

This PR adds a call to the socket's `close` method during `disconnect`.

Closes #137