### PR TITLE
make interface header optional on method calls

### DIFF
--- a/dbus_next/message_bus.py
+++ b/dbus_next/message_bus.py
@@ -760,9 +760,12 @@ class BaseMessageBus:
                 for method in ServiceInterface._get_methods(interface):
                     if method.disabled:
                         continue
-                    if msg._matches(interface=interface.name,
-                                    member=method.name,
-                                    signature=method.in_signature):
+                    if msg.interface is None and msg._matches(
+                            member=method.name,
+                            signature=method.in_signature
+                        ) or msg._matches(interface=interface.name,
+                                          member=method.name,
+                                          signature=method.in_signature):
                         handler = self._make_method_handler(interface, method)
                         break
                 if handler:


### PR DESCRIPTION
The dbus spec allows the interface to be optional on method calls. In that case, allow the message to match on any method with a matching name and signature.

https://github.com/altdesktop/python-dbus-next/issues/163